### PR TITLE
Porting to new API + qanimationframe, adapting tests, improve README

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,23 @@
+{
+    "globals": {
+      "window": true,
+      "document": true
+    },
+    "indent": 4,
+    "node": true,
+    "bitwise": true,
+    "camelcase": true,
+    "eqeqeq": true,
+    "immed": true,
+    "latedef": true,
+    "undef": true,
+    "unused": true,
+    "trailing": true,
+    "smarttabs": false,
+    "forin": false,
+    "browser": false,
+    "globalstrict": false,
+    "esnext": false,
+    "quotmark": false
+
+}

--- a/README.md
+++ b/README.md
@@ -67,73 +67,43 @@ Zanimo(myDomElement).then(function (elt) {
 });
 ~~~
 
-### Zanimo.transition(elt, property, value, duration, [timingFunction])  ➜  promise[elt]
+
+### Zanimo(elt, property, value) ➜  promise[elt]
+
+Applies a css style on the given DOM element.
+
+~~~ javascript
+Zanimo(myDomElement, "transform", "translate3d(200px, 200px, 0)")
+    .then(function (domElt) { console.log("Done..."); });
+~~~
+
+
+### Zanimo(elt, property, value, duration, [timingFunction])  ➜  promise[elt]
 
 Starts a transition on the given DOM element and returns a promise.
 For now Zanimo does not support hexadecimal color notation or 0px (just use 0) in the value argument.
 
 ~~~ javascript
-Zanimo
-    .transition(myDomElement, "width", "200px", 200, "ease-in")
+Zanimo(myDomElement, "width", "200px", 200, "ease-in")
     .then(
         function (domElt) { /* do something on success */ },
         function (reason) { /* do something on error */ }
     );
 ~~~
 
-### Zanimo.transitionf(property, value, duration, [timingFunction])  ➜  ( function(elt) ➜  promise[elt] )
+### Zanimo.f(*)  ➜  ( function(elt) ➜  promise[elt] )
 
-Encapsulates `Zanimo.transition()` in a function. Useful to define reusable transitions.
+Encapsulates a `Zanimo(elt, *)` call by returning a function (elt)➜promise[elt]. 
+
+Useful to define reusable transitions.
 
 ~~~ javascript
-var widthTransition = Zanimo.transitionf("width", "200px", 200, "ease-in"),
-    heightTransition = Zanimo.transitionf("height", "300px", 200, "ease-in");
+var widthTransition = Zanimo.f("width", "200px", 200, "ease-in"),
+    heightTransition = Zanimo.f("height", "300px", 200, "ease-in");
 
 Zanimo(myDomElement)
     .then(widthTransition)
     .then(heightTransition);
-~~~
-
-### Zanimo.transform(elt, value, [overwrite])  ➜  promise[elt]
-
-Applies a css transform on the given DOM element.
-
-~~~ javascript
-Zanimo
-    .transform(myDomElement, "translate3d(200px, 200px, 0)")
-    .then(function (domElt) { console.log("Done..."); });
-~~~
-
-### Zanimo.transformf(value, [overwrite])  ➜  ( function(elt) ➜  promise[elt] )
-
-Encapsulates `Zanimo.transform()` in a function. Useful for chaining.
-
-~~~ javascript
-Zanimo(myDomElt).then(Zanimo.transformf("scale(2)", true));
-~~~
-
-### Zanimo.all(array[function(elt) ➜  promise[elt]])  ➜  (function(elt) ➜  promise[elt])
-
-Helps executing multiple transitions in the same step.
-
-~~~ javascript
-var anim1 = Zanimo.transitionf("opacity", 0.5, 200),
-    anim2 = Zanimo.transitionf("width", "400px", 400);
-
-Zanimo(myDomElt).then(Zanimo.all([anim1, anim2]));
-~~~
-
-### Zanimo.f(elt|promise[elt]) ➜  ( function(elt) ➜  promise[elt] )
-
-Useful for changing a given DOM element along a promises chain.
-
-~~~ javascript
-var anim200pxLeft = Zanimo.transitionf("transform", "translate(200px, 0)", 200);
-
-Zanimo(myDomElement)
-    .then(anim200pxLeft)
-    .then(Zanimo.f(myOtherDomElement))
-    .then(anim200pxLeft)
 ~~~
 
 ## Credits

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "browser"
   ],
   "dependencies" : {
-    "q" : "0.9.7"
+    "q" : "0.9.7",
+    "qanimationframe": "2.0.1"
   },
   "devDependencies":{
     "grunt" : "~0.4.0",

--- a/src/Zanimo.js
+++ b/src/Zanimo.js
@@ -3,34 +3,12 @@
 
 (function (definition) {
     if (typeof exports === "object") {
-        module.exports = definition();
+        module.exports = definition(require("q"), require("qanimationframe"));
     } else {
-        Zanimo = definition();
+        window.Zanimo = definition(window.Q, window.QanimationFrame);
     }
 
-})(function () {
-    return (function () {
-
-    var Q = window.Q || require('q');
-
-    /**
-     * Provides requestAnimationFrame in a cross browser way.
-     * @author paulirish / http://paulirish.com/
-     */
-    if ( !window.requestAnimationFrame ) {
-        window.requestAnimationFrame = ( function() {
-
-            return window.webkitRequestAnimationFrame ||
-                window.mozRequestAnimationFrame ||
-                window.oRequestAnimationFrame ||
-                window.msRequestAnimationFrame ||
-            function( /* function FrameRequestCallback */ callback,
-                      /* DOMElement Element */ element ) {
-                window.setTimeout( callback, 1000 / 60 );
-            };
-
-        } )();
-    };
+})(function (Q, QanimationFrame) {
 
     /*
      * Private helper dealing with prefix and normalizing
@@ -69,33 +47,31 @@
                 return isNaN(val) ? val.replace(_matchParenthesis, _normCSSVal) : val.toString();
             };
 
-            // detect transition feature
-            if( 'WebkitTransition' in doc.body.style ) {
-                _transitionend = 'webkitTransitionEnd';
-                _prefix = "webkit";
-            }
+        // detect transition feature
+        if( 'WebkitTransition' in doc.body.style ) {
+            _transitionend = 'webkitTransitionEnd';
+            _prefix = "webkit";
+        }
 
-            for (var p in _prefixed)
-                _prefixed[p] = _prefix ? "-" + _prefix + "-" + p : p;
+        for (var p in _prefixed)
+            _prefixed[p] = _prefix ? "-" + _prefix + "-" + p : p;
 
-            _transition = _prefix ? _prefix + "-" + _transition : _transition
-            _transition = _norm(_transition);
-            _dummy = doc.createElement("div");
-            _dummyTransition = _normValue(_dummyTransition);
-            _dummy.style[_transition] = _dummyTransition;
-            _dummy = _normValue(_dummy.style[_transition]);
+        _transition = _prefix ? _prefix + "-" + _transition : _transition;
+        _transition = _norm(_transition);
+        _dummy = doc.createElement("div");
+        _dummyTransition = _normValue(_dummyTransition);
+        _dummy.style[_transition] = _dummyTransition;
+        _dummy = _normValue(_dummy.style[_transition]);
 
-            if (_dummy === _dummyTransition) {
-                _repr = function (v, d, t) {
-                    return v + " " + d + "ms " + (t || "linear") + " 0s";
-                };
-            }
+        if (_dummy === _dummyTransition) {
+            _repr = function (v, d, t) {
+                return v + " " + d + "ms " + (t || "linear") + " 0s";
+            };
+        }
 
         return {
             // prefixed transition string
             t : _transition,
-            // transform attr
-            transform : _norm(_prefixed["transform"]),
             // prefixed transition end event string
             transitionend : _transitionend,
             // normalize css property
@@ -114,180 +90,136 @@
         return domElt && domElt.nodeType ? true : false;
     },
 
-    /**
-     * Returns a fulfilled promise wrapping the given DOM element.
-     */
-    Z = function (domElt) {
-        if (isDOM(domElt)) {
-            return Q.resolve(domElt);
-        }
-        else if(Q.isPromise(domElt)) {
-            return domElt.then(Z);
-        }
-        else {
-            return Q.reject(new Error("Zanimo require an HTMLElement, or a promise of an HTMLElement"));
-        }
-    },
-
     // private helper to add a transition
-    add = function (domElt, attr, value, duration, timing) {
+    add = function (domElt, attr, value, duration, easing) {
         attr = T.prefix(attr);
         if (domElt.style[T.t]) {
-            domElt.style[T.t] = domElt.style[T.t]
-                                + ", "
-                                + T.repr(attr, duration, timing);
+            domElt.style[T.t] = domElt.style[T.t] +
+                                ", " +
+                                T.repr(attr, duration, easing);
         }
         else {
-            domElt.style[T.t] = T.repr(attr, duration, timing);
+            domElt.style[T.t] = T.repr(attr, duration, easing);
         }
         domElt.style[T.norm(attr)] = value;
     },
 
     // private helper to remove a transition
-    remove = function (domElt, attr, value, duration, timing) {
-        var prefixedAttr = T.prefix(attr),
-            keys = [];
+    remove = function (domElt, attr/*, value, duration, easing*/) {
+        var keys = [];
         for (var k in domElt._zanimo) {
-          keys.push(k);
+            keys.push(k);
         }
         if(keys.length === 1 && keys[0] === attr) domElt.style[T.t] = "";
     };
 
     /**
-     * Starts a transition on the given DOM element and returns
-     * a promise wrapping the DOM element.
+     * Zanimo(elt)
+     * > Returns a Promise of elt.
+     *
+     * Zanimo(elt, attr, value)
+     * > Sets elt.style[attr]=value and returns the Promise of elt.
+     *
+     * Zanimo(elt, attr, value, duration)
+     * Zanimo(elt, attr, value, duration, easing)
+     * > Performs a transition.
      */
-    Z.transition = function (domElt, attr, value, duration, timing) {
-        var d = Q.defer(), timeout,
-            cb = function (clear) {
-                if (timeout) { clearTimeout(timeout); timeout = null; }
-                remove(domElt, attr, value, duration, timing);
-                domElt.removeEventListener(T.transitionend, cbTransitionend);
-                if (clear) { delete domElt._zanimo[attr]; }
-            },
-            cbTransitionend = function (evt) {
-                if(T.norm(evt.propertyName) === T.norm(T.prefix(attr))) {
-                    cb(true); d.resolve(domElt);
-                }
-            };
-
-        if (!isDOM(domElt)) {
-            d.reject(new Error("Zanimo transition: no DOM element!"));
-            return d.promise;
+    var Zanimo = function (elt, attr, value, duration, easing) {
+        var arity = arguments.length;
+        if (arity === 0 || arity === 2 || arity > 5) throw new Error("Zanimo: invalid arguments.");
+        if (Q.isPromise(elt)) {
+            return elt.then(function (elt) {
+                return Zanimo.apply(this, [elt].concat(Array.prototype.slice.call(arguments, 1)));
+            });
         }
-        if(window.isNaN(parseInt(duration, 10))) {
-            d.reject(new Error("Zanimo transition: duration must be an integer!"));
-            return d.promise;
-        }
-
-        domElt.addEventListener(T.transitionend, cbTransitionend);
-
-        window.requestAnimationFrame(function () {
-            add(domElt, attr, value, duration, timing);
-            timeout = setTimeout(function () {
-                var rawVal = domElt.style.getPropertyValue(T.prefix(attr)),
-                    domVal = T.normValue(rawVal),
-                    givenVal = T.normValue(value);
-
-                cb(true);
-                if (domVal === givenVal) { d.resolve(domElt); }
-                else {
-                    d.reject( new Error("Zanimo transition: "
-                        + domElt.id + " with " + attr + " = " + givenVal
-                        + ", DOM value=" + domVal
-                    ));
-                }
-            }, duration + 20 );
-
-            domElt._zanimo = domElt._zanimo || { };
-            if(domElt._zanimo[attr]) {
-                domElt._zanimo[attr].defer.reject(new Error("Zanimo transition "
-                    + domElt.id + " with "
-                    + attr + "=" + domElt._zanimo[attr].value
-                    + " stopped by transition with " + attr + "=" + value
-                ));
-                domElt._zanimo[attr].cb();
-            }
-            domElt._zanimo[attr] = {cb: cb, value: value, defer: d};
-
-        }, domElt);
-
-        return d.promise;
-    };
-
-    /**
-     * A function wrapping Zanimo.transition().
-     */
-    Z.transitionf = function (attr, value, duration, timing) {
-        return function (elt) {
-            return Z.transition(elt, attr, value, duration, timing);
-        };
-    };
-
-    /**
-     * Apply a CSS3 transform value to a given DOM element
-     * and returns a promise wrapping the DOM element.
-     */
-    Z.transform = function (elt, value, overwrite) {
-        var d = Q.defer();
-
         if (!isDOM(elt)) {
-            d.reject(new Error("Zanimo transform: no DOM element!"));
+            throw new Error("Zanimo require an HTMLElement, or a promise of an HTMLElement");
+        }
+        if (arity === 1) {
+            return Q(elt);
+        }
+        else if (arity === 3) {
+            var prefixedAttr = T.prefix(attr);
+            if(elt._zanimo && elt._zanimo.hasOwnProperty(attr)) {
+                elt._zanimo[attr].defer.reject(new Error(
+                    "Zanimo transition " + elt.id + " with transform=" +
+                    elt._zanimo[attr].value +
+                    " stopped by transform=" + value
+                ));
+                elt._zanimo[attr].cb();
+            }
+            return QanimationFrame(function(){
+                elt.style[prefixedAttr] = value;
+                return elt;
+            });
+        }
+        else {
+            if(window.isNaN(parseInt(duration, 10))) {
+                throw new Error("Zanimo transition: duration must be an integer!");
+            }
+
+            var d = Q.defer(), timeout,
+                cb = function (clear) {
+                    if (timeout) { clearTimeout(timeout); timeout = null; }
+                    remove(elt, attr, value, duration, easing);
+                    elt.removeEventListener(T.transitionend, cbTransitionend);
+                    if (clear) { delete elt._zanimo[attr]; }
+                },
+                cbTransitionend = function (evt) {
+                    if(T.norm(evt.propertyName) === T.norm(T.prefix(attr))) {
+                        cb(true);
+                        d.resolve(elt);
+                    }
+                };
+
+            elt.addEventListener(T.transitionend, cbTransitionend);
+
+            QanimationFrame(function () {
+                add(elt, attr, value, duration, easing);
+                timeout = setTimeout(function () {
+                    var rawVal = elt.style.getPropertyValue(T.prefix(attr)),
+                        domVal = T.normValue(rawVal),
+                        givenVal = T.normValue(value);
+
+                    cb(true);
+                    if (domVal === givenVal) { d.resolve(elt); }
+                    else {
+                        d.reject( new Error("Zanimo transition: " +
+                            elt.id + " with " + attr + " = " + givenVal +
+                            ", DOM value=" + domVal
+                        ));
+                    }
+                }, duration + 20 );
+
+                elt._zanimo = elt._zanimo || { };
+                if(elt._zanimo[attr]) {
+                    elt._zanimo[attr].defer.reject(new Error(
+                        "Zanimo transition " +
+                        elt.id + " with " +
+                        attr + "=" + elt._zanimo[attr].value +
+                        " stopped by transition with " + attr + "=" + value
+                    ));
+                    elt._zanimo[attr].cb();
+                }
+                elt._zanimo[attr] = {cb: cb, value: value, defer: d};
+            });
+
             return d.promise;
         }
-
-        if(elt._zanimo && elt._zanimo.hasOwnProperty("transform")) {
-            elt._zanimo["transform"].defer.reject(new Error(
-                "Zanimo transition " + elt.id + " with transform="
-                + elt._zanimo["transform"].value
-                + " stopped by transform=" + value
-            ));
-            elt._zanimo["transform"].cb();
-        }
-
-        window.requestAnimationFrame(function () {
-            elt.style[T.transform] =
-                !overwrite ? elt.style[T.transform] + " " + value : value;
-            d.resolve(elt);
-        }, elt);
-        return d.promise;
     };
 
     /**
-     * A function wrapping Zanimo.transform().
+     * A function wrapping `Zanimo(elt, ...)` as a `f(...)(elt)` for easy chaining purpose.
      */
-    Z.transformf = function (value, overwrite) {
+    Zanimo.f = function (/*attr, value, duration, easing*/) {
+        var args = Array.prototype.slice.call(arguments);
         return function (elt) {
-            return Z.transform(elt, value, overwrite);
+            return Zanimo.apply(this, [elt].concat(args));
         };
     };
 
-    /**
-     * A function wrapping Zanimo().
-     */
-    Z.f = function (elt) {
-        return function () {
-            return Z(elt);
-        };
-    };
+    Zanimo._T = T;
 
-    /**
-     * Needed to run parallel Zanimo animations.
-     */
-    Z.all = function (flist) {
-        return function (el) {
-            return Q.all(flist.map(function (f) { return f(el); }))
-                    .then(function (plist) {
-                        var rejected = plist.filter(function (p) { return Q.isRejected(p); });
-                        if(rejected.length) return Q.reject(rejected);
-                        else return el;
-                    });
-        }
-    };
-
-    Z._T = T;
-
-    return Z;
-})();
+    return Zanimo;
 
 });

--- a/test/index.html
+++ b/test/index.html
@@ -15,7 +15,8 @@
         <p id="qunit-testresult" class="result"></p>
 
         <script type="text/javascript" src="../vendor/q-0.9.7.js"></script>
-        <script type="text/javascript" src="../dist/zanimo-0.0.9.js"></script>
+        <script type="text/javascript" src="../vendor/qanimationframe-2.0.1.js"></script>
+        <script type="text/javascript" src="../src/Zanimo.js"></script>
 
         <script type="text/javascript" src="specs.js"></script>
         <script type="text/javascript" src="test-suite.js"></script>

--- a/test/test-suite.js
+++ b/test/test-suite.js
@@ -30,7 +30,7 @@ function setDown2 (val) {
 Specs.test("Zanimo() rejects with no DOM element", function () {
 
     return Q.when(Q.delay(200), function () {
-        return Q.all([Zanimo("Oops"), Zanimo(), Zanimo([1,2,3])])
+        return Q.all([Q.fcall(Zanimo, "Oops"), Q.fcall(Zanimo), Q.fcall(Zanimo, [1,2,3])])
                 .then(Specs.fail("Resolve"), Specs.done("Reject"));
     });
 });
@@ -76,15 +76,15 @@ Specs.test("Zanimo() fail with a promise of a number", function () {
 });
 
 /*
- * Testing Zanimo.transition()
+ * Testing Zanimo()
  */
 Specs.test(
-    "Zanimo.transition: width to 300px in 400ms with ease-in-out",
+    "Zanimo: width to 300px in 400ms with ease-in-out",
     function () {
         var elt = setUp1();
 
         return Q.when(Q.delay(200), function () {
-            return Zanimo.transition(elt, "width", "300px", 400, "ease-in-out")
+            return Zanimo(elt, "width", "300px", 400, "ease-in-out")
                     .then(Specs.done("Resolve"), Specs.fail("Reject"))
                     .then(setDown1, setDown1);
         });
@@ -92,14 +92,14 @@ Specs.test(
 );
 
 Specs.test(
-    "Zanimo.transition: width and height to 300px in 400ms with ease-in-out",
+    "Zanimo: width and height to 300px in 400ms with ease-in-out",
     function () {
         var elt = setUp1();
 
         return Q.when(Q.delay(200), function () {
                 return Q.all([
-                    Zanimo.transition(elt, "width", "300px", 400, "ease-in-out"),
-                    Zanimo.transition(elt, "height", "300px", 400, "ease-in-out")
+                    Zanimo(elt, "width", "300px", 400, "ease-in-out"),
+                    Zanimo(elt, "height", "300px", 400, "ease-in-out")
                 ])
                 .then(Specs.done("Resolve"), Specs.fail("Reject"))
                 .then(setDown1, setDown1);
@@ -108,7 +108,7 @@ Specs.test(
 );
 
 Specs.test(
-    "Zanimo.transition: chaining 2 transition with 2 elements",
+    "Zanimo: chaining 2 transition with 2 elements",
     function () {
         var elt1 = setUp1(),
             elt2 = setUp2(),
@@ -118,9 +118,9 @@ Specs.test(
             };
 
         return Q.when(Q.delay(200), function () {
-            return Zanimo.transition(elt1, "transform", "translate(200px, 0)", 300)
+            return Zanimo(elt1, "transform", "translate(200px, 0)", 300)
                      .then(function () {
-                         return Zanimo.transition(elt2, "transform", "translate(0, 200px)", 100);
+                         return Zanimo(elt2, "transform", "translate(0, 200px)", 100);
                      })
                      .then(Specs.done("Resolve"), Specs.fail("Reject"))
                      .then(down, down);
@@ -129,24 +129,22 @@ Specs.test(
 );
 
 Specs.test(
-    "Zanimo.transition: call with wrong DOM element",
+    "Zanimo: call with wrong DOM element",
     function () {
         return Q.when(Q.delay(200), function () {
-            return Zanimo
-                    .transition("Oops", "opacity", 1, 100)
+            return Q.fcall(Zanimo, "Oops", "opacity", 1, 100)
                     .then(Specs.fail("Resolve"), Specs.done("Reject"));
         });
     }
 );
 
 Specs.test(
-    "Zanimo.transition: call with wrong transition property",
+    "Zanimo: call with wrong transition property",
     function () {
         var elt = setUp1();
 
         return Q.when(Q.delay(200), function () {
-            return Zanimo
-                    .transition(elt, "toto", "test", 100)
+            return Q.fcall(Zanimo, elt, "toto", "test", 100)
                     .then(Specs.fail("Resolve"), Specs.done("Reject"))
                     .then(setDown1, setDown1);
         });
@@ -154,13 +152,12 @@ Specs.test(
 );
 
 Specs.test(
-    "Zanimo.transition: call with wrong time value",
+    "Zanimo: call with wrong time value",
     function () {
         var elt = setUp1();
 
         return Q.when(Q.delay(200), function () {
-            return Zanimo
-                    .transition(elt, "opacity", 0.5, "oops", "linear")
+            return Q.fcall(Zanimo, elt, "opacity", 0.5, "oops", "linear")
                     .then(Specs.fail("Resolve"), Specs.done("Reject"))
                     .then(setDown1, setDown1);
         });
@@ -168,14 +165,14 @@ Specs.test(
 );
 
 /*
- * Testing Zanimo.transitionf()
+ * Testing Zanimo.f()
  */
 Specs.test("opacity transition from 1 to 0 in 200ms", function () {
     var elt = setUp1();
 
     return Q.when(Q.delay(200), function () {
         return Zanimo(elt)
-                .then(Zanimo.transitionf("opacity", 0, 2000))
+                .then(Zanimo.f("opacity", 0, 2000))
                 .then(Specs.done("Resolve"), Specs.fail("Reject"))
                 .then(setDown1, setDown1);
     });
@@ -186,7 +183,7 @@ Specs.test("display can't handle transitions!", function () {
 
     return Q.when(Q.delay(200), function () {
         return Zanimo(elt)
-                .then(Zanimo.transitionf("display", 1, 100))
+                .then(Zanimo.f("display", 1, 100))
                 .then(Specs.fail("Resolve"), Specs.done("Reject"))
                 .then(setDown1, setDown1);
     });
@@ -197,7 +194,7 @@ Specs.test("translate(200px, 0) 200ms", function () {
 
     return Q.when(Q.delay(200), function () {
         return Zanimo(elt)
-                .then(Zanimo.transitionf("transform", "translate(200px, 0)", 200))
+                .then(Zanimo.f("transform", "translate(200px, 0)", 200))
                 .then(Specs.done("Resolve"), Specs.fail("Reject"))
                 .then(setDown1, setDown1);
     });
@@ -208,7 +205,7 @@ Specs.test("background-color to blue in 200ms", function () {
 
     return Q.when(Q.delay(200), function () {
         return Zanimo(elt)
-                .then(Zanimo.transitionf("background-color", "blue", 200))
+                .then(Zanimo.f("background-color", "blue", 200))
                 .then(Specs.done("Resolve"), Specs.fail("Reject"))
                 .then(setDown1, setDown1);
     });
@@ -218,11 +215,11 @@ Specs.test("background-color to blue in 200ms", function () {
  * Testing the behavior of multiple Zanimo transitions on the same element.
  */
 Specs.test(
-    "Zanimo.transition: 2 same transitions on the same element, part 1",
+    "Zanimo: 2 same transitions on the same element, part 1",
     function () {
         var elt = setUp1(),
-            transition1 = Zanimo.transitionf("transform", "translate(200px, 0)", 400),
-            transition2 = Zanimo.transitionf("transform", "translate(100px, 300px)", 100);
+            transition1 = Zanimo.f("transform", "translate(200px, 0)", 400),
+            transition2 = Zanimo.f("transform", "translate(100px, 300px)", 100);
 
         Q.when(Q.delay(200), function () {
             return Zanimo(elt).delay(100).then(transition2);
@@ -238,11 +235,11 @@ Specs.test(
 );
 
 Specs.test(
-    "Zanimo.transition: 2 same transitions on the same element, part 2",
+    "Zanimo: 2 same transitions on the same element, part 2",
     function () {
         var elt = setUp1(),
-            transition1 = Zanimo.transitionf("transform", "translate(200px, 0)", 400),
-            transition2 = Zanimo.transitionf("transform", "translate(100px, 300px)", 100);
+            transition1 = Zanimo.f("transform", "translate(200px, 0)", 400),
+            transition2 = Zanimo.f("transform", "translate(100px, 300px)", 100);
 
         Zanimo(elt).then(transition1);
 
@@ -260,28 +257,13 @@ Specs.test(
     }
 );
 
-/*
- * Test Zanimo.transform()
- */
 Specs.test(
-    "Zanimo.transform() with no DOM element",
-    function () {
-        return Q.when(Q.delay(200), function () {
-            return Zanimo
-                    .transform("Oops", "translate(100px, 0)")
-                    .then(Specs.fail("Resolve"), Specs.done("Reject"));
-        });
-    }
-);
-
-Specs.test(
-    "Zanimo.transform() with translate(200px, 0)",
+    "Zanimo transform with translate(200px, 0)",
     function () {
         var elt = setUp1();
 
         return Q.when(Q.delay(200), function () {
-            return Zanimo
-                    .transform(elt, "translate(200px, 0)")
+            return Zanimo(elt, "transform", "translate(200px, 0)")
                     .then(Specs.done("Resolve"), Specs.fail("Reject"))
                     .then(setDown1, setDown1);
         });
@@ -289,18 +271,17 @@ Specs.test(
 );
 
 Specs.test(
-    "Testing Zanimo.transform() and transition:transform on the same element part 1",
+    "Testing Zanimo transform and transition:transform on the same element part 1",
     function () {
         var elt = setUp1();
 
         Q.when(Q.delay(200), function () {
             return Zanimo(elt)
-                    .then(Zanimo.transition("transform", "translate(200px, 0)", 400));
+                    .then(Zanimo.f("transform", "translate(200px, 0)", 400));
         });
 
         return Q.when(Q.delay(200), function () {
-            return Zanimo
-                    .transform(elt, "translate(00px, 200px)")
+            return Zanimo(elt, "transform", "translate(00px, 200px)")
                     .then(Specs.done("Resolve"), Specs.fail("Reject"))
                     .then(setDown1, setDown1);
         });
@@ -308,101 +289,20 @@ Specs.test(
 );
 
 Specs.test(
-    "Testing Zanimo.transform() and transition:transform on the same element part 2",
+    "Testing Zanimo transform and transition:transform on the same element part 2",
     function () {
         var elt = setUp1();
 
         Q.delay(300).then(function () {
-             return Zanimo.transform(elt, "translate(00px, 200px)");
+             return Zanimo(elt, "transform", "translate(00px, 200px)");
         });
 
         return Q.when(Q.delay(200), function () {
             return Zanimo(elt)
-                    .then(Zanimo.transitionf("transform", "translate(200px, 0)", 400))
+                    .then(Zanimo.f("transform", "translate(200px, 0)", 400))
                     .then(Specs.fail("Resolve"), Specs.done("Reject"))
                     .then(setDown1, setDown1);
         });
-    }
-);
-
-/*
- * Test Zanimo.transformf()
- */
-Specs.test(
-    "Zanimo.transformf() 'scale(2.0)'",
-    function () {
-        var elt = setUp1();
-
-        return Q.when(Q.delay(200), function () {
-            return Zanimo(elt)
-                    .then(Zanimo.transformf("scale(2.0)"))
-                    .then(Specs.done("Resolve"), Specs.fail("Reject"))
-                    .then(setDown1, setDown1);
-        });
-    }
-);
-
-Specs.test(
-    "Zanimo.transformf(): overwrite=true on animated elt",
-    function () {
-        var elt = setUp1();
-
-        Q.delay(200).then(function () {
-             return Zanimo(elt)
-                      .then(Zanimo.transitionf("transform", "translate(200px, 0)", 400));
-        });
-
-        return Q.delay(300)
-                .then(Zanimo.f(elt))
-                .then(Zanimo.transformf("translate(0, 200px)", true))
-                .then(function (elt) {
-                    var d = Q.defer();
-                    if (Zanimo._T.normValue(elt.style[Zanimo._T.transform])
-                        === Zanimo._T.normValue("translate(0, 200px)")) {
-                        d.resolve(elt);
-                    }
-                    else {
-                        d.reject(new Error("Fail: "
-                            + Zanimo._T.normValue(elt.style[Zanimo._T.transform])
-                            + " " + Zanimo._T.normValue("translate(200px, 0)")
-                        ));
-                    }
-                    return d.promise;
-                })
-                .then(Specs.done("Resolve"), Specs.fail("Reject"))
-                .then(setDown1, setDown1);
-    }
-);
-
-Specs.test(
-    "Zanimo.transformf(): overwrite=false on animated elt",
-    function () {
-        var elt = setUp1();
-
-        Q.delay(200).then(function () {
-             return Zanimo(elt)
-                      .then(Zanimo.transitionf("transform", "translate(200px, 0)", 400));
-        });
-
-        return Q.delay(300)
-                .then(Zanimo.f(elt))
-                .then(Zanimo.transformf("translate(0, 200px)"))
-                .then(function (elt) {
-                    var d = Q.defer();
-                    if (Zanimo._T.normValue(elt.style[Zanimo._T.transform])
-                        === Zanimo._T.normValue("translate(200px, 0) translate(0, 200px)")) {
-                        d.resolve(elt);
-                    }
-                    else {
-                        d.reject(new Error("Fail: "
-                            + Zanimo._T.normValue(elt.style[Zanimo._T.transform])
-                            + " " + Zanimo._T.normValue("translate(200px, 0) translate(200px, 0)")
-                        ));
-                    }
-                    return d.promise;
-                })
-                .then(Specs.done("Resolve"), Specs.fail("Reject"))
-                .then(setDown1, setDown1);
     }
 );
 
@@ -410,7 +310,7 @@ Specs.test(
  * Test Zanimo.f()
  */
 Specs.test(
-    "Zanimo.f() resolve with a HTML element",
+    "Using Q.thenResolve with a HTML element",
     function () {
         var elt1 = setUp1(),
             elt2 = setUp2(),
@@ -418,9 +318,9 @@ Specs.test(
 
         return Q.when(Q.delay(200), function () {
             return Zanimo(elt1)
-                    .then(Zanimo.transitionf("opacity", 0.5, 100, "ease-in"))
-                    .then(Zanimo.f(elt2))
-                    .then(Zanimo.transitionf("opacity", 0.5, 100, "ease-in"))
+                    .then(Zanimo.f("opacity", 0.5, 100, "ease-in"))
+                    .thenResolve(elt2)
+                    .then(Zanimo.f("opacity", 0.5, 100, "ease-in"))
                     .then(Specs.done("Resolve"), Specs.fail("Reject"))
                     .then(down, down);
         });
@@ -428,25 +328,10 @@ Specs.test(
 );
 
 Specs.test(
-    "Zanimo.f() rejects without a DOM element",
-    function () {
-        var elt = setUp1();
-
-        return Q.when(Q.delay(200), function () {
-            return Zanimo(elt)
-                    .then(Zanimo.transitionf("opacity", 0.5, 100, "ease-in"))
-                    .then(Zanimo.f())
-                    .then(Specs.fail("Resolve"), Specs.done("Reject"))
-                    .then(setDown1, setDown1);
-        });
-    }
-);
-
-Specs.test(
-    "Zanimo.transition: make 4 same transitions sequentially with the same element (opacity)",
+    "Zanimo: make 4 same transitions sequentially with the same element (opacity)",
     function () {
         var elt = setUp1(),
-            transition1 = Zanimo.transitionf("opacity", 0, 200),
+            transition1 = Zanimo.f("opacity", 0, 200),
             opacity1 = function (elt) {
                 elt.style.opacity = 1;
                 return elt;
@@ -468,11 +353,11 @@ Specs.test(
 );
 
 Specs.test(
-    "Zanimo.transition: make 4 same transitions sequentially with the same element (transform)",
+    "Zanimo: make 4 same transitions sequentially with the same element (transform)",
     function () {
         var elt = setUp1(),
-            transition1 = Zanimo.transitionf("transform", "translate(200px, 0)", 500),
-            transform1 = Zanimo.transformf("translate(0,0)", true);
+            transition1 = Zanimo.f("transform", "translate(200px, 0)", 500),
+            transform1 = Zanimo.f("transform", "translate(0,0)");
 
         return Q.when(Q.delay(200), function () {
             return Zanimo(elt)
@@ -493,12 +378,14 @@ Specs.test(
     "Zanimo.all: 2 transitions on the same element",
     function () {
         var elt = setUp1(),
-            anim1 = Zanimo.transitionf("opacity", 0, 100),
-            anim2 = Zanimo.transitionf("background-color", "orange", 800);
+            anim1 = Zanimo.f("opacity", 0, 100),
+            anim2 = Zanimo.f("background-color", "orange", 800);
 
         return Q.when(Q.delay(200), function () {
             return Zanimo(elt)
-                    .then(Zanimo.all([anim1, anim2]))
+                    .then(function(elt) {
+                        return Q.all([ anim1(elt), anim2(elt) ]).thenResolve(elt);
+                    })
                     .then(Specs.done("Resolve"), Specs.fail("Reject"))
                     .then(setDown1, setDown1);
         });
@@ -509,14 +396,16 @@ Specs.test(
     "Zanimo.all: 2 transitions on the same element and one failed",
     function () {
         var elt = setUp1(),
-            anim1 = Zanimo.transitionf("opacity", 0, 100),
+            anim1 = Zanimo.f("opacity", 0, 100),
             fail1 = function (el) {
                 return Q.reject(new Error("Ooooooops"));
             };
 
         return Q.when(Q.delay(200), function () {
             return Zanimo(elt)
-                    .then(Zanimo.all([anim1, fail1]))
+                    .then(function(elt) {
+                        return Q.all([ anim1(elt), fail1(elt) ]).thenResolve(elt);
+                    })
                     .then(Specs.fail("Resolve"), Specs.done("Reject"))
                     .then(setDown1, setDown1);
         });

--- a/vendor/qanimationframe-2.0.1.js
+++ b/vendor/qanimationframe-2.0.1.js
@@ -1,0 +1,45 @@
+/*
+ * Qanimationframe.js - Promisified requestAnimationFrame with Q
+ */
+/*jslint newcap: true */
+(function (definition) {
+    if (typeof exports === "object") {
+        module.exports = definition();
+    } else {
+        window.QanimationFrame = definition();
+    }
+})(function () {
+  "use strict";
+
+  // Import Q
+  var Q = window.Q || require("q");
+
+  // requestAnimationFrame polyfill
+  var requestAnimationFrame = (function(){
+    return window.requestAnimationFrame       ||
+           window.oRequestAnimationFrame      ||
+           window.msRequestAnimationFrame     ||
+           window.mozRequestAnimationFrame    ||
+           window.webkitRequestAnimationFrame ||
+           function (callback) {
+             window.setTimeout(callback, 1000 / 60);
+           };
+  })();
+
+  // QanimationFrame(f: function) => DOM.Element
+  // ---
+  //
+  var QanimationFrame = function (f) {
+    var d = Q.defer();
+    requestAnimationFrame(function () {
+      try {
+        d.resolve(f());
+      } catch (e) {
+        d.reject(e);
+      }
+    });
+    return d.promise;
+  };
+
+  return QanimationFrame;
+});


### PR DESCRIPTION
Here is an implementation of the new API, Test should pass, however I had to remove some of them because of API changes.

I also took some choices we can discuss:

**I added QanimationFrame dependency** and use it for the "transition" and the "set attribute" API usage, which also have the benefit of catching `elt.style[attr]=value` exception which can happen on IE.

**I chosed to prefer to throw Error as much as possible** instead of returning a failure Promise because those are easier to detect (generally because of bad Zanimo API usage), once the Zanimo call is wrapped in a Promise the exception is obviously transformed into a Failure promise.

Things to be done:
- While we now have an API for setting a CSS style, It would be a good idea to depends on a proper prefix library to have all CSS properties working. When migrating to this prefix library, we will have to refactor/clean the T object, and I suggest we don't expose it anymore.
- I haven't migrate the main index.html but I think you want to remove it according to #7

Please don't merge it yet, we will have to test it more and maybe we can refactor the prefix part as previously said ;)

Thanks
